### PR TITLE
fix warning: conversion from a string literal to "char *" is deprecated

### DIFF
--- a/plotly/plotly.nw
+++ b/plotly/plotly.nw
@@ -35,9 +35,9 @@ The plotly structure is used to display CEO graphics using \url{plot.ly}.
 struct plotly_properties{
   <<properties parameters>>
   <<properties default>>
-  int set(char *param, char *value);
-  int set(char *param, float *value, int N);
-  int set(char *param, float *value, int N, int M);
+  int set(const char *param, const char *value);
+  int set(const char *param, float *value, int N);
+  int set(const char *param, float *value, int N, int M);
 };
 	
 void imagesc(plotly_properties *p);
@@ -148,7 +148,7 @@ plotly_properties(void)
 \label{sec:set-plotly-prop}
 
 <<set plotly char properties>>=
-int plotly_properties::set(char *param, char *value)
+int plotly_properties::set(const char *param, const char *value)
 {
   int s = -1;
   s = strcmp("filename",param);
@@ -190,7 +190,7 @@ int plotly_properties::set(char *param, char *value)
 }
 
 <<set plotly float properties>>=
-int plotly_properties::set(char *param, float *value, int N)
+int plotly_properties::set(const char *param, float *value, int N)
 {
   int s = -1;
   s = strcmp("xdata",param);
@@ -209,7 +209,7 @@ int plotly_properties::set(char *param, float *value, int N)
 }
 
 <<set plotly 2D float properties>>=
-int plotly_properties::set(char *param, float *value, int N, int M)
+int plotly_properties::set(const char *param, float *value, int N, int M)
 {
   int s = -1, nel;
   s = strcmp("zdata",param);

--- a/source/source.nw
+++ b/source/source.nw
@@ -28,24 +28,24 @@ struct source {
 
   <<source parameters>>
 
-  void setup(char *_photometric_band, 
+  void setup(const char *_photometric_band, 
 	     float zenith, float azimuth, float height);
-  void setup(char *_photometric_band, 
+  void setup(const char *_photometric_band, 
 	     float zenith, float azimuth, float height, 
 	     int resolution);
-  void setup(char *_photometric_band, 
+  void setup(const char *_photometric_band, 
 	     float zenith, float azimuth, float height, 
-	     char *tag_in);
-  void setup(char *_photometric_band, 
+	     const char *tag_in);
+  void setup(const char *_photometric_band, 
 	     float zenith, float azimuth, float height, 
-	     int resolution, char *tag_in);
-  void setup(char *_photometric_band, 
+	     int resolution, const char *tag_in);
+  void setup(const char *_photometric_band, 
 	     float *_zenith, float *_azimuth, float _height, 
 	     int _N_SRC);
-  void setup(char *_photometric_band, 
+  void setup(const char *_photometric_band, 
 	     float *_zenith, float *_azimuth, float _height, 
 	     int _N_SRC, int resolution);
-  void setup(char *_photometric_band, 
+  void setup(const char *_photometric_band, 
 	     float *_zenith, float *_azimuth, float _height, 
 	     int _N_SRC, rtd _L_, int _N_L_, vector origin);
   void cleanup(void);
@@ -151,14 +151,14 @@ cdef extern from "source.h":
         void rms(float *)
     cdef cppclass source:
         int N_SRC
-        char *photometric_band
+        const char *photometric_band
         float fwhm, magnitude
         complex_amplitude wavefront
         bundle rays
-        void setup(char *,float , float , float )
-	void setup(char *,float , float , float , int )
-        void setup(char *,float *, float *, float , int , int )
-        void setup(char *,float *, float *, float , int , rtd, int, vector)
+        void setup(const char *,float , float , float )
+	void setup(const char *,float , float , float , int )
+        void setup(const char *,float *, float *, float , int , int )
+        void setup(const char *,float *, float *, float , int , rtd, int, vector)
         void cleanup()
         void reset_rays()
         void trace(gmt_m1 *)
@@ -609,7 +609,7 @@ float *amplitude, *phase;
 mask *M;
 @ The magnitude at a given photometric band are set with:
 <<source parameters>>=
-char *photometric_band;
+const char *photometric_band;
 float magnitude;
 @ If the source is resolved by the  optical system, the irradiance is assumed to have a Gaussian shape of full width a half maximum [[fwhm]]
 <<source parameters>>=
@@ -639,7 +639,7 @@ Sources are initialized with the setup function:
 \begin{itemize}
 \item for a single source:
 <<setup>>=
-void source::setup(char *_photometric_band, 
+void source::setup(const char *_photometric_band, 
 		   float _zenith, float _azimuth, 
 		   float _height) {
   <<setup single source contents>>
@@ -649,7 +649,7 @@ void source::setup(char *_photometric_band,
 }
 @ \item for a single source with wavefront resolution:
 <<setup with wavefront resolution>>=
-void source::setup(char *_photometric_band, 
+void source::setup(const char *_photometric_band, 
 		   float _zenith, float _azimuth, 
 		   float _height, int resolution) {
   <<setup single source contents>>
@@ -659,9 +659,9 @@ void source::setup(char *_photometric_band,
 }
 @ \item for a single source with tag:
 <<setup with tag>>=
-void source::setup(char *_photometric_band, 
+void source::setup(const char *_photometric_band, 
 		   float _zenith, float _azimuth, 
-		   float _height, char *tag_in) {
+		   float _height, const char *tag_in) {
   <<setup single source contents>>
   wavefront.setup(0);
   strcpy(tag,tag_in);
@@ -669,9 +669,9 @@ void source::setup(char *_photometric_band,
 }
 @ \item for a single source with wavefront resolution and tag:
 <<setup with wavefront resolution and tag>>=
-void source::setup(char *_photometric_band, 
+void source::setup(const char *_photometric_band, 
 		   float _zenith, float _azimuth, float _height, 
-		   int resolution, char *tag_in) {
+		   int resolution, const char *tag_in) {
   <<setup single source contents>>
   wavefront.setup(resolution);
   strcpy(tag,tag_in);
@@ -702,7 +702,7 @@ HANDLE_ERROR( cudaMemcpy( dev_ptr, &__src,
 
 @ \item for multiple sources:
 <<setup for multiple sources>>=
-void source::setup(char *_photometric_band, 
+void source::setup(const char *_photometric_band, 
 		   float *_zenith, float *_azimuth, 
 		   float _height, int _N_SRC) {
   rays_exist = 0;
@@ -735,7 +735,7 @@ void source::setup(char *_photometric_band,
 }
 @  \item for multiple sources with wavefront resolution:
 <<setup for multiple sources with wavefront resolution>>=
-void source::setup(char *_photometric_band, 
+void source::setup(const char *_photometric_band, 
 		   float *_zenith, float *_azimuth, float _height, 
 		   int _N_SRC, int resolution) {
   rays_exist = 0;
@@ -769,7 +769,7 @@ void source::setup(char *_photometric_band,
 }
 @  \item for multiple sources with wavefront resolution and with ray bundle:
 <<setup for multiple sources with wavefront resolution and ray bundle>>=
-void source::setup(char *_photometric_band, 
+void source::setup(const char *_photometric_band, 
 		   float *_zenith, float *_azimuth, float _height, 
 		   int _N_SRC, rtd L, int N_L, vector origin) {
   N_SRC = _N_SRC;

--- a/utilities/utilities.nw
+++ b/utilities/utilities.nw
@@ -378,7 +378,7 @@ struct stopwatch{
     HANDLE_ERROR( cudaEventDestroy( start ) );
     HANDLE_ERROR( cudaEventDestroy( stop ) );
   }
-  void toc(char *message) {
+  void toc(const char *message) {
     HANDLE_ERROR( cudaEventRecord( stop, 0 ) );
     HANDLE_ERROR( cudaEventSynchronize( stop ) );
     float   elapsedTime;
@@ -388,7 +388,7 @@ struct stopwatch{
     HANDLE_ERROR( cudaEventDestroy( start ) );
     HANDLE_ERROR( cudaEventDestroy( stop ) );
   }
-  void toc(float *elapsedTime, char *message) {
+  void toc(float *elapsedTime, const char *message) {
     HANDLE_ERROR( cudaEventRecord( stop, 0 ) );
     HANDLE_ERROR( cudaEventSynchronize( stop ) );
     HANDLE_ERROR( cudaEventElapsedTime( elapsedTime,


### PR DESCRIPTION
cuda-7.5 compiler emits stricter warnings when compiling CEO

%/usr/local/cuda-7.5/bin/nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2015 NVIDIA Corporation
Built on Tue_Aug_11_14:27:32_CDT_2015
Cuda compilation tools, release 7.5, V7.5.17
